### PR TITLE
Fix function range detection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,7 +129,9 @@ async function getFunctionRangeByIndent(doc: vscode.TextDocument, startPos: vsco
 	
 	// 関数の終了行を見つける
 	let endLine = actualBodyStart;
-	const baseIndentForComparison = actualBodyIndent !== -1 ? defIndent : defIndent;
+        // Use the detected body indent when available for a more accurate
+        // comparison; fall back to the definition indent otherwise.
+        const baseIndentForComparison = actualBodyIndent !== -1 ? actualBodyIndent : defIndent;
 	
 	for (let i = actualBodyStart + 1; i < lines.length; i++) {
 		const line = lines[i];


### PR DESCRIPTION
## Summary
- correct indentation comparison when detecting function ranges

## Testing
- `npm test` *(fails: Cannot find module 'vscode' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683f65b5b9c8832cbaa3c4791c5956f4