### PR TITLE
Persist virtualenv across extension updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ OwlSpotlight transforms code navigation by bringing **semantic understanding** t
    pip install -r requirements.txt
    ```
 
+   The extension now stores the virtual environment outside of its own folder so
+   it won't be removed when OwlSpotlight is updated. By default it is created in
+   VS Code's global storage directory. You can override this location with the
+   `owlspotlight.environmentSettings.venvPath` setting.
+
 4. **Launch**: Run the commands from Option 1, steps 2-4
 
 ### 💡 Why OwlSpotlight?
@@ -135,6 +140,8 @@ source .venv/bin/activate          # macOS/Linux
 
 pip install -r requirements.txt
 ```
+
+The created environment will be kept outside the extension's directory (under VS Code's global storage) so it persists after updates. You can change the location via `owlspotlight.environmentSettings.venvPath`.
 
 **Performance Tips**:
 - Use SSD storage for faster indexing
@@ -227,6 +234,8 @@ OwlSpotlightは、VS CodeでPythonコードを自然言語で検索できる拡�
    source .venv/bin/activate  # Windows: .venv\Scripts\activate
    pip install -r requirements.txt
    ```
+
+   仮想環境は拡張機能の更新で削除されないよう、既定でVS Codeのグローバルストレージに作成されます。`owlspotlight.environmentSettings.venvPath` 設定で任意の場所に変更できます。
 
 ### OwlSpotlightを選ぶ理由
 

--- a/package.json
+++ b/package.json
@@ -126,6 +126,11 @@
               "type": "string",
               "default": "3.11",
               "description": "Python version to use for virtual environment (requires pyenv on macOS/Linux)"
+            },
+            "venvPath": {
+              "type": "string",
+              "default": "",
+              "description": "Custom path for Python virtual environment. Leave empty to use a persistent directory in VS Code global storage"
             }
           }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -633,15 +633,19 @@ function updatePythonServerConfig() {
 		!l.startsWith('OWLSETTINGS_BATCH_SIZE=') &&
 		!l.startsWith('OWLSETTINGS_AUTO_CLEAR_CACHE=') &&
 		!l.startsWith('OWLSETTINGS_AUTO_CLEAR_LOCAL_CACHE=') &&
-		!l.startsWith('OWLSETTINGS_CACHE_PATH=') &&
-		!l.startsWith('OWLSETTINGS_PYTHON_VERSION=')
-	);
-	lines.push(`OWL_BATCH_SIZE=${batchSize}`);
-	lines.push(`OWLSETTINGS_AUTO_CLEAR_CACHE=${cacheSettings.autoClearCache || false}`);
-	lines.push(`OWLSETTINGS_AUTO_CLEAR_LOCAL_CACHE=${cacheSettings.autoClearLocalCache || false}`);
-	lines.push(`OWLSETTINGS_CACHE_PATH=${cacheSettings.cachePath || ''}`);
-	lines.push(`OWLSETTINGS_PYTHON_VERSION=${envSettings.pythonVersion || '3.11'}`);
-	fs.writeFileSync(envPath, lines.join('\n'));
+                !l.startsWith('OWLSETTINGS_CACHE_PATH=') &&
+                !l.startsWith('OWLSETTINGS_PYTHON_VERSION=') &&
+                !l.startsWith('OWLSETTINGS_VENV_PATH=')
+        );
+        lines.push(`OWL_BATCH_SIZE=${batchSize}`);
+        lines.push(`OWLSETTINGS_AUTO_CLEAR_CACHE=${cacheSettings.autoClearCache || false}`);
+        lines.push(`OWLSETTINGS_AUTO_CLEAR_LOCAL_CACHE=${cacheSettings.autoClearLocalCache || false}`);
+        lines.push(`OWLSETTINGS_CACHE_PATH=${cacheSettings.cachePath || ''}`);
+        lines.push(`OWLSETTINGS_PYTHON_VERSION=${envSettings.pythonVersion || '3.11'}`);
+        const defaultVenv = path.join(context.globalStorageUri.fsPath, 'owlspotlight_env');
+        const venvDir = envSettings.venvPath && envSettings.venvPath.trim() !== '' ? envSettings.venvPath : defaultVenv;
+        lines.push(`OWLSETTINGS_VENV_PATH=${venvDir}`);
+        fs.writeFileSync(envPath, lines.join('\n'));
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -668,16 +672,18 @@ export function activate(context: vscode.ExtensionContext) {
 	// サーバー起動コマンドはそのまま
 	const startServerDisposable = vscode.commands.registerCommand('owlspotlight.startServer', async () => {
 		const config = vscode.workspace.getConfiguration('owlspotlight');
-		const cacheSettings = config.get<any>('cacheSettings', {});
-		const autoClearCache = cacheSettings.autoClearCache || false;
-		const serverDir = path.join(context.extensionPath, 'model_server');
-		const venvDir = path.join(serverDir, '.venv');
-		const fs = require('fs');
+                const cacheSettings = config.get<any>('cacheSettings', {});
+                const envSettings = config.get<any>('environmentSettings', {});
+                const autoClearCache = cacheSettings.autoClearCache || false;
+                const serverDir = path.join(context.extensionPath, 'model_server');
+                const defaultVenv = path.join(context.globalStorageUri.fsPath, 'owlspotlight_env');
+                const venvDir = envSettings.venvPath && envSettings.venvPath.trim() !== '' ? envSettings.venvPath : defaultVenv;
+                const fs = require('fs');
 
 		// 仮想環境がなければ作成を促す
-		if (!fs.existsSync(venvDir)) {
-			const result = await vscode.window.showWarningMessage(
-				'No Python virtual environment (.venv) found. Would you like to set it up now?',
+                if (!fs.existsSync(venvDir)) {
+                        const result = await vscode.window.showWarningMessage(
+                                'No Python virtual environment found. Would you like to set it up now?',
 				{ modal: true },
 				'Yes, Setup',
 				'Cancel'
@@ -707,13 +713,15 @@ export function activate(context: vscode.ExtensionContext) {
 				cwd: serverDir
 			});
 			const platform = os.platform();
-			if (platform === 'win32') {
-				terminal.sendText('.\\.venv\\Scripts\\activate', true);
-				terminal.sendText('uvicorn server:app --host 127.0.0.1 --port 8000 --reload', true);
-			} else {
-				terminal.sendText('source .venv/bin/activate', true);
-				terminal.sendText('uvicorn server:app --host 127.0.0.1 --port 8000 --reload', true);
-			}
+                        if (platform === 'win32') {
+                                const activate = path.join(venvDir, 'Scripts', 'activate');
+                                terminal.sendText(`"${activate}"`, true);
+                                terminal.sendText('uvicorn server:app --host 127.0.0.1 --port 8000 --reload', true);
+                        } else {
+                                const activate = path.join(venvDir, 'bin', 'activate');
+                                terminal.sendText(`source "${activate}"`, true);
+                                terminal.sendText('uvicorn server:app --host 127.0.0.1 --port 8000 --reload', true);
+                        }
 			terminal.show();
 			vscode.window.showInformationMessage('OwlSpotlight server started in a new terminal.');
 		} catch (err) {
@@ -733,13 +741,14 @@ export function activate(context: vscode.ExtensionContext) {
 	// --- 環境セットアップコマンドを追加 ---
 	const setupEnvDisposable = vscode.commands.registerCommand('owlspotlight.setupEnv', async () => {
 		const config = vscode.workspace.getConfiguration('owlspotlight');
-		const envSettings = config.get<any>('environmentSettings', {});
-		const autoRemoveVenv = envSettings.autoRemoveVenv || false;
-		const pythonVersion = envSettings.pythonVersion || '3.11';
-		
-		const serverDir = path.join(context.extensionPath, 'model_server');
-		const venvDir = path.join(serverDir, '.venv');
-		const fs = require('fs');
+                const envSettings = config.get<any>('environmentSettings', {});
+                const autoRemoveVenv = envSettings.autoRemoveVenv || false;
+                const pythonVersion = envSettings.pythonVersion || '3.11';
+
+                const serverDir = path.join(context.extensionPath, 'model_server');
+                const defaultVenv = path.join(context.globalStorageUri.fsPath, 'owlspotlight_env');
+                const venvDir = envSettings.venvPath && envSettings.venvPath.trim() !== '' ? envSettings.venvPath : defaultVenv;
+                const fs = require('fs');
 		
 		// 自動削除設定がオンの場合、既存の仮想環境を削除
 		if (autoRemoveVenv && fs.existsSync(venvDir)) {
@@ -757,24 +766,26 @@ export function activate(context: vscode.ExtensionContext) {
 		});
 		terminal.show();
 		const platform = os.platform();
-		if (platform === 'win32') {
-			// Windows用: pyenvチェックはスキップ
-			terminal.sendText('python -m venv .venv', true);
-			terminal.sendText('.\\.venv\\Scripts\\activate', true);
-			terminal.sendText('python -m pip install --upgrade pip', true);
-			terminal.sendText('pip install -r requirements.txt', true);
-			vscode.window.showInformationMessage('OwlSpotlight Python environment setup command executed for Windows. Please start the server after setup completes.');
-		} else {
-			// macOS/Linux用: pyenvチェックあり
-			terminal.sendText('if ! command -v pyenv >/dev/null 2>&1; then echo "[OwlSpotlight] pyenv is not installed. Please install pyenv first. For example: brew install pyenv"; exit 1; fi', true);
-			terminal.sendText(`if ! pyenv versions --bare | grep -q "^${pythonVersion}"; then echo "[OwlSpotlight] Python ${pythonVersion} is not installed in pyenv. Please run: pyenv install ${pythonVersion}"; exit 1; fi`, true);
-			terminal.sendText(`pyenv local ${pythonVersion}`, true);
-			terminal.sendText(`python${pythonVersion} -m venv .venv`, true);
-			terminal.sendText('source .venv/bin/activate', true);
-			terminal.sendText('pip install --upgrade pip', true);
-			terminal.sendText('pip install -r requirements.txt', true);
-			vscode.window.showInformationMessage(`OwlSpotlight Python ${pythonVersion} environment setup command executed for macOS/Linux. Please ensure pyenv and Python ${pythonVersion} are installed. Start the server after setup completes.`);
-		}
+                if (platform === 'win32') {
+                        // Windows用: pyenvチェックはスキップ
+                        terminal.sendText(`python -m venv "${venvDir}"`, true);
+                        const activate = path.join(venvDir, 'Scripts', 'activate');
+                        terminal.sendText(`"${activate}"`, true);
+                        terminal.sendText('python -m pip install --upgrade pip', true);
+                        terminal.sendText('pip install -r requirements.txt', true);
+                        vscode.window.showInformationMessage('OwlSpotlight Python environment setup command executed for Windows. Please start the server after setup completes.');
+                } else {
+                        // macOS/Linux用: pyenvチェックあり
+                        terminal.sendText('if ! command -v pyenv >/dev/null 2>&1; then echo "[OwlSpotlight] pyenv is not installed. Please install pyenv first. For example: brew install pyenv"; exit 1; fi', true);
+                        terminal.sendText(`if ! pyenv versions --bare | grep -q "^${pythonVersion}"; then echo "[OwlSpotlight] Python ${pythonVersion} is not installed in pyenv. Please run: pyenv install ${pythonVersion}"; exit 1; fi`, true);
+                        terminal.sendText(`pyenv local ${pythonVersion}`, true);
+                        terminal.sendText(`python${pythonVersion} -m venv "${venvDir}"`, true);
+                        const activate = path.join(venvDir, 'bin', 'activate');
+                        terminal.sendText(`source "${activate}"`, true);
+                        terminal.sendText('pip install --upgrade pip', true);
+                        terminal.sendText('pip install -r requirements.txt', true);
+                        vscode.window.showInformationMessage(`OwlSpotlight Python ${pythonVersion} environment setup command executed for macOS/Linux. Please ensure pyenv and Python ${pythonVersion} are installed. Start the server after setup completes.`);
+                }
 	});
 	context.subscriptions.push(setupEnvDisposable);
 
@@ -839,10 +850,13 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(clearCacheDisposable);
 
 	// --- 仮想環境削除コマンドを追加 ---
-	const removeVenvDisposable = vscode.commands.registerCommand('owlspotlight.removeVenv', async () => {
-		const serverDir = path.join(context.extensionPath, 'model_server');
-		const venvDir = path.join(serverDir, '.venv');
-		const fs = require('fs');
+        const removeVenvDisposable = vscode.commands.registerCommand('owlspotlight.removeVenv', async () => {
+                const serverDir = path.join(context.extensionPath, 'model_server');
+                const config = vscode.workspace.getConfiguration('owlspotlight');
+                const envSettings = config.get<any>('environmentSettings', {});
+                const defaultVenv = path.join(context.globalStorageUri.fsPath, 'owlspotlight_env');
+                const venvDir = envSettings.venvPath && envSettings.venvPath.trim() !== '' ? envSettings.venvPath : defaultVenv;
+                const fs = require('fs');
 		
 		try {
 			if (fs.existsSync(venvDir)) {


### PR DESCRIPTION
## Summary
- add `venvPath` setting to control virtual environment location
- default to VS Code global storage so updates don't remove `.venv`
- adjust extension code to use the new path
- document how to keep the environment across updates

## Testing
- `npm run compile` *(fails: Cannot find module 'vscode')*
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm test` *(fails: Cannot find module 'vscode')*

------
https://chatgpt.com/codex/tasks/task_e_683f69b00dc8832c89eed7c3fd2a3d09