### PR TITLE
Add JavaScript code search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@
 
 ### 🚀 What is OwlSpotlight?
 
-OwlSpotlight transforms code navigation by bringing **semantic understanding** to your VS Code workspace. Instead of searching for exact matches, ask questions like *"function that validates email"* or *"class for handling database connections"* and instantly find relevant code across your entire Python project.
+OwlSpotlight transforms code navigation by bringing **semantic understanding** to your VS Code workspace. Instead of searching for exact matches, ask questions like *"function that validates email"* or *"class for handling database connections"* and instantly find relevant code across your entire Python or JavaScript project.
 
 ![Demo Preview](screenshot/detect_method_in_class.png)t
 
-**Instantly discover code with semantic search. A VS Code extension for searching Python functions, classes, and methods using natural language.**
+**Instantly discover code with semantic search. A VS Code extension for searching Python and JavaScript functions, classes, and methods using natural language.**
 
-**意味的検索でPython関数・クラス・メソッドを瞬時に発見できるVS Code拡張機能。**
+**意味的検索でPythonやJavaScriptの関数・クラス・メソッドを瞬時に発見できるVS Code拡張機能。**
 
 ---
 
@@ -145,14 +145,14 @@ pip install -r requirements.txt
 ### 🚧 Development Roadmap
 
 #### ✅ Current Features
-- [x] Natural language search for Python functions/classes/methods
+- [x] Natural language search for Python and JavaScript functions/classes/methods
 - [x] Real-time incremental indexing
 - [x] Apple Silicon optimization
 - [x] Class relationship visualization
 - [x] Advanced filtering and statistics
 
 #### 🔄 Coming Soon
-- [ ] **Multi-language support** (JavaScript, TypeScript, Java, C++)
+- [ ] **Additional language support** (TypeScript, Java, C++)
 - [ ] **CUDA/GPU acceleration** with flash-attention
 - [ ] **VS Code Marketplace** release
 - [ ] **Real-time file watching** (auto-update on save)
@@ -177,7 +177,7 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ### OwlSpotlightとは？
 
-OwlSpotlightは、VS CodeでPythonコードを自然言語で検索できる拡張機能です。
+OwlSpotlightは、VS CodeでPythonやJavaScriptコードを自然言語で検索できる拡張機能です。
 現在[Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Shun0212.owlspotlight)でも公開・配布しています。
 従来のキーワード検索とは異なり、「メールを検証する関数」や「データベース接続を処理するクラス」など、意図を表現したクエリで関連するコードを素早く見つけることができます。
 
@@ -254,14 +254,14 @@ pip install -r requirements.txt
 ### 開発ロードマップ
 
 #### 現在の機能
-- Python関数・クラス・メソッドの自然言語検索
+- PythonおよびJavaScriptの関数・クラス・メソッドを自然言語で検索
 - インクリメンタルインデックス更新
 - Apple Silicon対応
 - クラス構造の可視化
 - フィルタ・統計表示
 
 #### 今後の予定
-- 多言語対応（JavaScript, TypeScript, Java, C++など）
+- 追加言語サポート（TypeScript, Java, C++など）
 - CUDA/GPU対応
 - VS Code Marketplace公開
 - ファイル保存時の自動更新

--- a/package.json
+++ b/package.json
@@ -85,6 +85,11 @@
           "minimum": 1,
           "description": "Batch size for code embedding (Python server). Larger values may speed up indexing but use more memory."
         },
+        "owlspotlight.fileExt": {
+          "type": "string",
+          "default": ".py",
+          "description": "File extension to index and search (e.g., .py, .js, .ts)"
+        },
         "owlspotlight.cacheSettings": {
           "type": "object",
           "title": "Cache Settings",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -261,19 +261,21 @@ class OwlspotlightSidebarProvider implements vscode.WebviewViewProvider {
 					webviewView.webview.postMessage({ type: 'error', message: 'No workspace folder found' });
 					return;
 				}
-				const folderPath = workspaceFolders[0].uri.fsPath;
-				webviewView.webview.postMessage({ type: 'status', message: 'Building index...' });
-				await fetch('http://localhost:8000/build_index', {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ directory: folderPath, file_ext: '.py' })
-				});
+                                const folderPath = workspaceFolders[0].uri.fsPath;
+                                const cfg = vscode.workspace.getConfiguration('owlspotlight');
+                                const fileExt = cfg.get<string>('fileExt', '.py');
+                                webviewView.webview.postMessage({ type: 'status', message: 'Building index...' });
+                                await fetch('http://localhost:8000/build_index', {
+                                        method: 'POST',
+                                        headers: { 'Content-Type': 'application/json' },
+                                        body: JSON.stringify({ directory: folderPath, file_ext: fileExt })
+                                });
 				webviewView.webview.postMessage({ type: 'status', message: 'Searching...' });
-				const res = await fetch('http://localhost:8000/search_functions_simple', {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ directory: folderPath, query, top_k: 10 })
-				});
+                                const res = await fetch('http://localhost:8000/search_functions_simple', {
+                                        method: 'POST',
+                                        headers: { 'Content-Type': 'application/json' },
+                                        body: JSON.stringify({ directory: folderPath, query, top_k: 10, file_ext: fileExt })
+                                });
 				const data: any = await res.json();
 				if (data && data.results && Array.isArray(data.results) && data.results.length > 0) {
 					webviewView.webview.postMessage({ type: 'results', results: data.results, folderPath });
@@ -287,15 +289,17 @@ class OwlspotlightSidebarProvider implements vscode.WebviewViewProvider {
 					webviewView.webview.postMessage({ type: 'error', message: 'No workspace folder found' });
 					return;
 				}
-				const folderPath = workspaceFolders[0].uri.fsPath;
-				const query = msg.query || ''; // クエリパラメータを受け取る
-				webviewView.webview.postMessage({ type: 'status', message: 'Loading class statistics...' });
-				try {
-					const res = await fetch('http://localhost:8000/get_class_stats', {
-						method: 'POST',
-						headers: { 'Content-Type': 'application/json' },
-						body: JSON.stringify({ directory: folderPath, query: query, top_k: 50 })
-					});
+                                const folderPath = workspaceFolders[0].uri.fsPath;
+                                const query = msg.query || ''; // クエリパラメータを受け取る
+                                const cfg = vscode.workspace.getConfiguration('owlspotlight');
+                                const fileExt = cfg.get<string>('fileExt', '.py');
+                                webviewView.webview.postMessage({ type: 'status', message: 'Loading class statistics...' });
+                                try {
+                                        const res = await fetch('http://localhost:8000/get_class_stats', {
+                                                method: 'POST',
+                                                headers: { 'Content-Type': 'application/json' },
+                                                body: JSON.stringify({ directory: folderPath, query: query, top_k: 50, file_ext: fileExt })
+                                        });
 					const data: any = await res.json();
 					webviewView.webview.postMessage({ type: 'classStats', data, folderPath });
 				} catch (error) {
@@ -464,14 +468,16 @@ class OwlspotlightSidebarProvider implements vscode.WebviewViewProvider {
 					webviewView.webview.postMessage({ type: 'error', message: 'No workspace folder found' });
 					return;
 				}
-				const folderPath = workspaceFolders[0].uri.fsPath;
-				webviewView.webview.postMessage({ type: 'status', message: 'Clearing cache and rebuilding index...' });
-				try {
-					const res = await fetch('http://localhost:8000/force_rebuild_index', {
-						method: 'POST',
-						headers: { 'Content-Type': 'application/json' },
-						body: JSON.stringify({ directory: folderPath, file_ext: '.py' })
-					});
+                                const folderPath = workspaceFolders[0].uri.fsPath;
+                                const cfg = vscode.workspace.getConfiguration('owlspotlight');
+                                const fileExt = cfg.get<string>('fileExt', '.py');
+                                webviewView.webview.postMessage({ type: 'status', message: 'Clearing cache and rebuilding index...' });
+                                try {
+                                        const res = await fetch('http://localhost:8000/force_rebuild_index', {
+                                                method: 'POST',
+                                                headers: { 'Content-Type': 'application/json' },
+                                                body: JSON.stringify({ directory: folderPath, file_ext: fileExt })
+                                        });
 					const data = await res.json();
 					const msg = typeof data === 'object' && data && 'message' in data ? (data as any).message : undefined;
 					webviewView.webview.postMessage({ type: 'status', message: msg || 'Cache cleared and index rebuilt.' });


### PR DESCRIPTION
## Summary
- support JavaScript/TypeScript extraction with new parser
- allow endpoints to handle configurable `file_ext`
- respect `owlspotlight.fileExt` setting in extension
- document JavaScript support in README

## Testing
- `npm test` *(fails: Cannot find name 'fetch' etc.)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f68a36820832c95b8e691bae05122