### PR TITLE
Add persistent virtual environment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ source .venv/bin/activate          # macOS/Linux
 pip install -r requirements.txt
 ```
 
+To keep the Python environment between extension updates, set `owlspotlight.environmentSettings.venvPath` in your VS Code settings. When specified, the setup and server commands will use this directory instead of the extension folder, preventing the virtual environment from being removed on update.
+
 **Performance Tips**:
 - Use SSD storage for faster indexing
 - Allocate more RAM for large projects

--- a/package.json
+++ b/package.json
@@ -122,6 +122,11 @@
               "default": false,
               "description": "Automatically remove existing virtual environment before setup. WARNING: This will delete all installed packages!"
             },
+            "venvPath": {
+              "type": "string",
+              "default": "",
+              "description": "Custom path for the Python virtual environment. Leave empty to use the extension folder"
+            },
             "pythonVersion": {
               "type": "string",
               "default": "3.11",


### PR DESCRIPTION
## Summary
- add `venvPath` setting to keep Python venv outside extension folder
- update extension code to honor new setting when starting, setting up or removing env
- record setting in `.env` file for the server
- document the option in README

## Testing
- `npm run compile`
- `npm run lint`
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com/api/releases/stable due to network restrictions)*

------
