### PR TITLE
Display class ranking by method priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ OwlSpotlight transforms code navigation by bringing **semantic understanding** t
 |---------|-------------|---------|
 | **🔍 Semantic Function Search** | Find functions by describing what they do in natural language | ![Function Search](screenshot/detect_function.png) |
 | **🏗️ Class & Method Discovery** | Explore class hierarchies and their methods with context-aware search | ![Class Methods](screenshot/detect_method_in_class.png) |
-| **📊 Intelligent Ranking** | View classes ranked by relevance with detailed statistics | ![Class Rankings](screenshot/class_stats_mode.png) |
+| **📊 Intelligent Ranking** | View classes ranked by relevance with detailed statistics. Methods inside each class are ordered by their search rank so you can see which ones boosted the score. | ![Class Rankings](screenshot/class_stats_mode.png) |
 | **⚙️ Environment Management** | Built-in alerts and management for Python environments | ![Environment Alert](screenshot/alart_No_venv.png) |
 
 ### 🚀 Quick Start

--- a/media/main.js
+++ b/media/main.js
@@ -130,11 +130,11 @@ window.onload = function() {
 				// メソッド一覧
 				const methodsDiv = document.createElement('div');
 				methodsDiv.className = 'stats-methods';
-				classInfo.methods.forEach(method => {
-					const methodDiv = document.createElement('div');
-					methodDiv.className = 'stats-method-item';
-					methodDiv.setAttribute('data-file', method.file_path);
-					methodDiv.setAttribute('data-line', method.lineno);
+                                classInfo.methods.forEach(method => {
+                                        const methodDiv = document.createElement('div');
+                                        methodDiv.className = 'stats-method-item';
+                                        methodDiv.setAttribute('data-file', method.file_path);
+                                        methodDiv.setAttribute('data-line', method.lineno);
 					
 					let relPath = method.file_path || '';
 					if (relPath && relPath.startsWith(currentFolderPath)) {
@@ -144,10 +144,11 @@ window.onload = function() {
 						}
 					}
 					
-					methodDiv.innerHTML = `
-						<div class="method-name">${method.name}</div>
-						<div class="method-path">${relPath}:${method.lineno}</div>
-					`;
+                                        const rankInfo = method.search_rank ? ` (rank: ${method.search_rank})` : '';
+                                        methodDiv.innerHTML = `
+                                                <div class="method-name">${method.name}${rankInfo}</div>
+                                                <div class="method-path">${relPath}:${method.lineno}</div>
+                                        `;
 					
 					methodDiv.onclick = function() {
 						vscode.postMessage({ 


### PR DESCRIPTION
## Summary
- sort methods in `get_class_stats` by search rank and store `search_rank`
- show method rank in sidebar UI
- clarify that classes show methods ordered by search rank in README

## Testing
- `npm run lint`
- `npm run test` *(fails to fetch VS Code release JSON but tests run)*

------
https://chatgpt.com/codex/tasks/task_e_683fae620390832c8b39f487abb5d62c