### PR TITLE
Add language auto detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ pip install -r requirements.txt
 - [x] Class relationship visualization
 - [x] Advanced filtering and statistics
 - [x] Experimental Java support
+- [x] Automatic language detection with selectable options
 
 #### 🔄 Coming Soon
 - [ ] **Multi-language support** (JavaScript, TypeScript, Java, C++)


### PR DESCRIPTION
## Summary
- detect Python and Java languages present in the workspace
- use detected languages to populate the dropdown
- hide the dropdown if only one language detected
- document automatic language detection feature in README

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to parse response ... due to network)*

------
