### PR TITLE
Add CI workflows and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,11 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
-      - run: npm test
+      - name: Setup display for VS Code
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+      - name: Run tests
+        run: xvfb-run -a npm test
+        env:
+          DISPLAY: ':99'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      - run: sudo apt-get update && sudo apt-get install -y xvfb
+      - run: xvfb-run -a npm test
       - run: npm run compile
       - run: npx vsce package
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish Extension
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run compile
+      - run: npx vsce package
+      - uses: actions/upload-artifact@v3
+        with:
+          name: vsix
+          path: '*.vsix'
+      - run: npx vsce publish -p "$VSCE_TOKEN"
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - run: npm run compile
       - run: npm run lint
       - run: sudo apt-get update && sudo apt-get install -y xvfb
-      - run: xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' npm test
+      - run: /usr/bin/xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' npx vscode-test
       - run: npx vsce package
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - run: npm run compile
       - run: npm run lint
       - run: sudo apt-get update && sudo apt-get install -y xvfb
-      - run: xvfb-run -a npm test
+      - run: xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' npm test
       - run: npx vsce package
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,10 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      - run: npm run compile
+      - run: npm run lint
       - run: sudo apt-get update && sudo apt-get install -y xvfb
       - run: xvfb-run -a npm test
-      - run: npm run compile
       - run: npx vsce package
       - uses: actions/upload-artifact@v3
         with:

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -2,7 +2,14 @@ import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
-	useInstallation: {
-		fromMachine: true
+	version: 'stable',
+	launchArgs: [
+		'--headless',
+		'--disable-gpu',
+		'--disable-dev-shm-usage',
+		'--no-sandbox'
+	],
+	env: {
+		DISPLAY: ':99'
 	}
 });

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -2,4 +2,7 @@ import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
+	useInstallation: {
+		fromMachine: true
+	}
 });

--- a/README.md
+++ b/README.md
@@ -270,6 +270,15 @@ pip install -r requirements.txt
 - ファイル保存時の自動更新
 - クラス継承図の表示
 
+### 自動テストとデプロイ
+
+GitHub Actions を利用した CI ワークフローを追加しました。`main` ブランチへのプッシュや
+プルリクエスト時に `npm test` と `eslint` を実行して拡張機能をビルドします。
+
+タグ `v*.*.*` を作成すると、自動的に VS Code 拡張機能 (`vsix` ファイル) を生成し、
+`vsce publish` を使用してマーケットプレースへ公開できます。発行用のトークンは
+`VSCE_TOKEN` シークレットに設定してください。
+
 ### ライセンス
 
 MIT License - 詳細は[LICENSE](LICENSE)をご覧ください。

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "owlspotlight",
   "description": "Highlight similar code snippets using semantic search.",
   "publisher": "Shun0212",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "keywords": [
     "semantic search",
     "code search",

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -6,10 +6,30 @@ import * as vscode from 'vscode';
 // import * as myExtension from '../../extension';
 
 suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+    vscode.window.showInformationMessage('Start all tests.');
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
+    test('Sample test', () => {
+        assert.strictEqual(-1, [1, 2, 3].indexOf(5));
+        assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+    });
+
+    test('Extension should activate', async () => {
+        const ext = vscode.extensions.getExtension('Shun0212.owlspotlight');
+        await ext?.activate();
+        assert.ok(ext?.isActive, 'Extension is not active');
+    });
+
+    test('Commands are registered', async () => {
+        const cmds = await vscode.commands.getCommands(true);
+        const expected = [
+            'owlspotlight.startServer',
+            'owlspotlight.searchCode',
+            'owlspotlight.setupEnv',
+            'owlspotlight.clearCache',
+            'owlspotlight.removeVenv'
+        ];
+        for (const cmd of expected) {
+            assert.ok(cmds.includes(cmd), `${cmd} not found`);
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for linting and testing
- add workflow for publishing extension with vsce
- extend sample tests to verify activation and command registration
- document CI and deployment setup in README

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com/api/releases/stable?released=true as JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68404efce8fc832c8057bb8e4a7d4d2a