### PR TITLE
Add config for custom SentenceTransformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ OwlSpotlight transforms code navigation by bringing **semantic understanding** t
 - Simple, intuitive sidebar interface
 - Apple Silicon optimized
 - Built-in cache clearing and environment management
+- Customizable SentenceTransformer model via settings
 
 ### See It In Action
 
@@ -135,6 +136,8 @@ source .venv/bin/activate          # macOS/Linux
 
 pip install -r requirements.txt
 ```
+
+You can change the embedding model by modifying the `owlspotlight.modelSettings.modelName` setting in VS Code. By default it uses `Shuu12121/CodeSearch-ModernBERT-Owl-2.0-Plus`.
 
 **Performance Tips**:
 - Use SSD storage for faster indexing

--- a/model_server/model.py
+++ b/model_server/model.py
@@ -1,7 +1,10 @@
 from sentence_transformers import SentenceTransformer
 import numpy as np
+import os
 
-model = SentenceTransformer("Shuu12121/CodeSearch-ModernBERT-Owl-2.0-Plus")
+DEFAULT_MODEL = "Shuu12121/CodeSearch-ModernBERT-Owl-2.0-Plus"
+model_name = os.environ.get("OWL_MODEL_NAME", DEFAULT_MODEL)
+model = SentenceTransformer(model_name)
 
 def encode_code(codes: list[str], batch_size: int = 32) -> np.ndarray:
     return model.encode(codes, batch_size=batch_size, normalize_embeddings=True)

--- a/model_server/server.py
+++ b/model_server/server.py
@@ -38,7 +38,9 @@ import numpy as np
 app = FastAPI()
 
 # モデルロード
-model = SentenceTransformer("Shuu12121/CodeSearch-ModernBERT-Owl-2.0-Plus")
+DEFAULT_MODEL = "Shuu12121/CodeSearch-ModernBERT-Owl-2.0-Plus"
+model_name = os.environ.get("OWL_MODEL_NAME", DEFAULT_MODEL)
+model = SentenceTransformer(model_name)
 model_device = None  # 現在のデバイスを記録
 
 # === 設定: バッチサイズなど ===

--- a/package.json
+++ b/package.json
@@ -128,6 +128,18 @@
               "description": "Python version to use for virtual environment (requires pyenv on macOS/Linux)"
             }
           }
+        },
+        "owlspotlight.modelSettings": {
+          "type": "object",
+          "title": "Model Settings",
+          "description": "Configure embedding model",
+          "properties": {
+            "modelName": {
+              "type": "string",
+              "default": "Shuu12121/CodeSearch-ModernBERT-Owl-2.0-Plus",
+              "description": "Hugging Face model name used for embeddings"
+            }
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
       "type": "object",
       "title": "OwlSpotlight Settings",
       "properties": {
+        "owlspotlight.modelName": {
+          "type": "string",
+          "default": "Shuu12121/CodeSearch-ModernBERT-Owl-2.0-Plus",
+          "description": "Hugging Face model name used for embeddings"
+        },
         "owlspotlight.batchSize": {
           "type": "number",
           "default": 32,
@@ -126,18 +131,6 @@
               "type": "string",
               "default": "3.11",
               "description": "Python version to use for virtual environment (requires pyenv on macOS/Linux)"
-            }
-          }
-        },
-        "owlspotlight.modelSettings": {
-          "type": "object",
-          "title": "Model Settings",
-          "description": "Configure embedding model",
-          "properties": {
-            "modelName": {
-              "type": "string",
-              "default": "Shuu12121/CodeSearch-ModernBERT-Owl-2.0-Plus",
-              "description": "Hugging Face model name used for embeddings"
             }
           }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -641,37 +641,37 @@ function setupDecorationListeners() {
 
 // 拡張機能設定の監視とPythonサーバーへの反映
 function updatePythonServerConfig() {
-        const config = vscode.workspace.getConfiguration('owlspotlight');
-        const batchSize = config.get<number>('batchSize', 32);
-        const cacheSettings = config.get<any>('cacheSettings', {});
-        const envSettings = config.get<any>('environmentSettings', {});
-        const modelSettings = config.get<any>('modelSettings', {});
-	
-	// .envファイルに書き込む
-	const fs = require('fs');
-	const path = require('path');
-	const serverDir = path.join(__dirname, '..', 'model_server');
-	const envPath = path.join(serverDir, '.env');
-	let envContent = '';
-	if (fs.existsSync(envPath)) {
-		envContent = fs.readFileSync(envPath, 'utf8');
-	}
-        const lines = envContent.split(/\r?\n/).filter((l: string) =>
-                !l.startsWith('OWL_BATCH_SIZE=') &&
-                !l.startsWith('OWLSETTINGS_BATCH_SIZE=') &&
-                !l.startsWith('OWLSETTINGS_AUTO_CLEAR_CACHE=') &&
-                !l.startsWith('OWLSETTINGS_AUTO_CLEAR_LOCAL_CACHE=') &&
-                !l.startsWith('OWLSETTINGS_CACHE_PATH=') &&
-                !l.startsWith('OWLSETTINGS_PYTHON_VERSION=') &&
-                !l.startsWith('OWL_MODEL_NAME=')
-        );
-	lines.push(`OWL_BATCH_SIZE=${batchSize}`);
-	lines.push(`OWLSETTINGS_AUTO_CLEAR_CACHE=${cacheSettings.autoClearCache || false}`);
-	lines.push(`OWLSETTINGS_AUTO_CLEAR_LOCAL_CACHE=${cacheSettings.autoClearLocalCache || false}`);
-        lines.push(`OWLSETTINGS_CACHE_PATH=${cacheSettings.cachePath || ''}`);
-        lines.push(`OWLSETTINGS_PYTHON_VERSION=${envSettings.pythonVersion || '3.11'}`);
-        lines.push(`OWL_MODEL_NAME=${modelSettings.modelName || 'Shuu12121/CodeSearch-ModernBERT-Owl-2.0-Plus'}`);
-        fs.writeFileSync(envPath, lines.join('\n'));
+    const config = vscode.workspace.getConfiguration('owlspotlight');
+    const batchSize = config.get<number>('batchSize', 32);
+    const cacheSettings = config.get<any>('cacheSettings', {});
+    const envSettings = config.get<any>('environmentSettings', {});
+    const modelName = config.get<string>('modelName', 'Shuu12121/CodeSearch-ModernBERT-Owl-2.0-Plus');
+
+    // .envファイルに書き込む
+    const fs = require('fs');
+    const path = require('path');
+    const serverDir = path.join(__dirname, '..', 'model_server');
+    const envPath = path.join(serverDir, '.env');
+    let envContent = '';
+    if (fs.existsSync(envPath)) {
+        envContent = fs.readFileSync(envPath, 'utf8');
+    }
+    const lines = envContent.split(/\r?\n/).filter((l: string) =>
+        !l.startsWith('OWL_BATCH_SIZE=') &&
+        !l.startsWith('OWLSETTINGS_BATCH_SIZE=') &&
+        !l.startsWith('OWLSETTINGS_AUTO_CLEAR_CACHE=') &&
+        !l.startsWith('OWLSETTINGS_AUTO_CLEAR_LOCAL_CACHE=') &&
+        !l.startsWith('OWLSETTINGS_CACHE_PATH=') &&
+        !l.startsWith('OWLSETTINGS_PYTHON_VERSION=') &&
+        !l.startsWith('OWL_MODEL_NAME=')
+    );
+    lines.push(`OWL_BATCH_SIZE=${batchSize}`);
+    lines.push(`OWLSETTINGS_AUTO_CLEAR_CACHE=${cacheSettings.autoClearCache || false}`);
+    lines.push(`OWLSETTINGS_AUTO_CLEAR_LOCAL_CACHE=${cacheSettings.autoClearLocalCache || false}`);
+    lines.push(`OWLSETTINGS_CACHE_PATH=${cacheSettings.cachePath || ''}`);
+    lines.push(`OWLSETTINGS_PYTHON_VERSION=${envSettings.pythonVersion || '3.11'}`);
+    lines.push(`OWL_MODEL_NAME=${modelName}`);
+    fs.writeFileSync(envPath, lines.join('\n'));
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -914,9 +914,12 @@ export function activate(context: vscode.ExtensionContext) {
 	// 設定変更時にPythonサーバーの設定を更新
 	context.subscriptions.push(
 		vscode.workspace.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('owlspotlight.batchSize') || 
+			if (
+				e.affectsConfiguration('owlspotlight.batchSize') ||
 				e.affectsConfiguration('owlspotlight.cacheSettings') ||
-				e.affectsConfiguration('owlspotlight.environmentSettings')) {
+				e.affectsConfiguration('owlspotlight.environmentSettings') ||
+				e.affectsConfiguration('owlspotlight.modelName')
+			) {
 				updatePythonServerConfig();
 			}
 		})

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -641,10 +641,11 @@ function setupDecorationListeners() {
 
 // 拡張機能設定の監視とPythonサーバーへの反映
 function updatePythonServerConfig() {
-	const config = vscode.workspace.getConfiguration('owlspotlight');
-	const batchSize = config.get<number>('batchSize', 32);
-	const cacheSettings = config.get<any>('cacheSettings', {});
-	const envSettings = config.get<any>('environmentSettings', {});
+        const config = vscode.workspace.getConfiguration('owlspotlight');
+        const batchSize = config.get<number>('batchSize', 32);
+        const cacheSettings = config.get<any>('cacheSettings', {});
+        const envSettings = config.get<any>('environmentSettings', {});
+        const modelSettings = config.get<any>('modelSettings', {});
 	
 	// .envファイルに書き込む
 	const fs = require('fs');
@@ -655,20 +656,22 @@ function updatePythonServerConfig() {
 	if (fs.existsSync(envPath)) {
 		envContent = fs.readFileSync(envPath, 'utf8');
 	}
-	const lines = envContent.split(/\r?\n/).filter((l: string) => 
-		!l.startsWith('OWL_BATCH_SIZE=') &&
-		!l.startsWith('OWLSETTINGS_BATCH_SIZE=') &&
-		!l.startsWith('OWLSETTINGS_AUTO_CLEAR_CACHE=') &&
-		!l.startsWith('OWLSETTINGS_AUTO_CLEAR_LOCAL_CACHE=') &&
-		!l.startsWith('OWLSETTINGS_CACHE_PATH=') &&
-		!l.startsWith('OWLSETTINGS_PYTHON_VERSION=')
-	);
+        const lines = envContent.split(/\r?\n/).filter((l: string) =>
+                !l.startsWith('OWL_BATCH_SIZE=') &&
+                !l.startsWith('OWLSETTINGS_BATCH_SIZE=') &&
+                !l.startsWith('OWLSETTINGS_AUTO_CLEAR_CACHE=') &&
+                !l.startsWith('OWLSETTINGS_AUTO_CLEAR_LOCAL_CACHE=') &&
+                !l.startsWith('OWLSETTINGS_CACHE_PATH=') &&
+                !l.startsWith('OWLSETTINGS_PYTHON_VERSION=') &&
+                !l.startsWith('OWL_MODEL_NAME=')
+        );
 	lines.push(`OWL_BATCH_SIZE=${batchSize}`);
 	lines.push(`OWLSETTINGS_AUTO_CLEAR_CACHE=${cacheSettings.autoClearCache || false}`);
 	lines.push(`OWLSETTINGS_AUTO_CLEAR_LOCAL_CACHE=${cacheSettings.autoClearLocalCache || false}`);
-	lines.push(`OWLSETTINGS_CACHE_PATH=${cacheSettings.cachePath || ''}`);
-	lines.push(`OWLSETTINGS_PYTHON_VERSION=${envSettings.pythonVersion || '3.11'}`);
-	fs.writeFileSync(envPath, lines.join('\n'));
+        lines.push(`OWLSETTINGS_CACHE_PATH=${cacheSettings.cachePath || ''}`);
+        lines.push(`OWLSETTINGS_PYTHON_VERSION=${envSettings.pythonVersion || '3.11'}`);
+        lines.push(`OWL_MODEL_NAME=${modelSettings.modelName || 'Shuu12121/CodeSearch-ModernBERT-Owl-2.0-Plus'}`);
+        fs.writeFileSync(envPath, lines.join('\n'));
 }
 
 export function activate(context: vscode.ExtensionContext) {


### PR DESCRIPTION
## Summary
- allow choosing embedding model via `OWL_MODEL_NAME`
- expose new `modelSettings.modelName` setting in extension
- persist model name in `.env`
- update docs to describe using custom models

## Testing
- `npm run lint`
- `npm run compile`
- `python3 -m py_compile model_server/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68404ea22d04832ca0d61a532aa000d4