### PR TITLE
Improve model switching and progress control

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ pip install -r requirements.txt
 
 You can change the embedding model by modifying the `owlspotlight.modelSettings.modelName` setting in VS Code. By default it uses `Shuu12121/CodeSearch-ModernBERT-Owl-2.0-Plus`.
 
+Progress bars during embedding can be disabled by setting the environment variable `OWL_PROGRESS=0`.
+
 **Performance Tips**:
 - Use SSD storage for faster indexing
 - Allocate more RAM for large projects


### PR DESCRIPTION
## Summary
- show embedding dimension after loading model
- add OWL_PROGRESS env var to control tqdm output
- disable progress bars for small batches
- document OWL_PROGRESS in README

## Testing
- `python -m py_compile model_server/model.py`
- `python -m py_compile model_server/server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68413784c034832cabc042aacc9455b3