### PR TITLE
Add GUI controls for Gemini translation

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -46,13 +46,27 @@ window.onload = function() {
 	    vscode.postMessage({ command: 'startServer' });
 	  };
 	}
-	if (document.getElementById('clearCacheBtn')) {
+        if (document.getElementById('clearCacheBtn')) {
           document.getElementById('clearCacheBtn').onclick = () => {
             console.log('clearCacheBtn clicked');
             const lang = document.getElementById('languageSelect')?.value || '.py';
             vscode.postMessage({ command: 'clearCache', lang });
           };
         }
+
+        // 翻訳設定の保存
+        const translateToggle = document.getElementById('translateToggle');
+        const geminiInput = document.getElementById('geminiApiKeyInput');
+        const saveTransBtn = document.getElementById('saveTranslationBtn');
+        if (saveTransBtn) {
+          saveTransBtn.onclick = () => {
+            const enable = translateToggle?.checked || false;
+            const apiKey = geminiInput?.value || '';
+            vscode.postMessage({ command: 'updateTranslationSettings', enable, apiKey });
+          };
+        }
+
+        vscode.postMessage({ command: 'requestTranslationSettings' });
 	
 	document.getElementById('searchBtn').onclick = () => {
                 const text = (document.getElementById('searchInput')).value;
@@ -243,11 +257,17 @@ window.onload = function() {
 	}
 
 	// メッセージハンドラー
-	window.addEventListener('message', event => {
-		const msg = event.data;
-		if (msg.type === 'status') {
-			document.getElementById('status').textContent = msg.message;
-		}
+        window.addEventListener('message', event => {
+                const msg = event.data;
+                if (msg.type === 'translationSettings') {
+                        const tToggle = document.getElementById('translateToggle');
+                        const apiInput = document.getElementById('geminiApiKeyInput');
+                        if (tToggle) { tToggle.checked = !!msg.enable; }
+                        if (apiInput && typeof msg.apiKey === 'string') { apiInput.value = msg.apiKey; }
+                }
+                if (msg.type === 'status') {
+                        document.getElementById('status').textContent = msg.message;
+                }
 		if (msg.type === 'error') {
 			document.getElementById('status').textContent = msg.message;
 			document.getElementById('results').innerHTML = '';

--- a/media/styles.css
+++ b/media/styles.css
@@ -70,6 +70,27 @@ body {
   letter-spacing: 0.02em;
 }
 
+.translation-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  padding: 0.8em 1em;
+  border-bottom: 1px solid var(--vscode-sideBarSectionHeader-border, #e0e0e0);
+  background: var(--vscode-sideBarSectionHeader-background, var(--vscode-sideBar-background, #f8f8f8));
+}
+.translation-settings input[type="text"] {
+  padding: 0.4em;
+  border-radius: 4px;
+  border: 1px solid var(--vscode-input-border, #c8c8c8);
+  background: var(--vscode-input-background, #ffffff);
+  color: var(--vscode-input-foreground, #333333);
+}
+.translation-settings label {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+}
+
 button { 
   padding: 0.2em 0.8em; 
   border-radius: 4px; 


### PR DESCRIPTION
## Summary
- add translation toggle and API key input to sidebar
- send translation settings to the webview and allow updates
- style the new controls and handle user actions

## Testing
- `npm run compile`
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com/api/releases/stable?released=true as JSON)*

------
https://chatgpt.com/codex/tasks/task_e_6841b9ae42b4832c8e182b14d6d34887