### PR TITLE
Remove LibreTranslate translation

### DIFF
--- a/media/help.html
+++ b/media/help.html
@@ -19,13 +19,11 @@
   </ul>
   <h3>Translation Settings / 翻訳設定</h3>
   <ul>
-    <li><b>Gemini API Translation:</b> To use Google Gemini for translation, go to VS Code Settings and configure:<br>
-      <code>owlspotlight.translationSettings.translationProvider</code> to <b>"gemini"</b><br>
+    <li><b>Gemini API Translation:</b> To use Google Gemini for translation, configure in VS Code Settings:<br>
       <code>owlspotlight.translationSettings.geminiApiKey</code> to your <b>Gemini API key</b><br>
       <code>owlspotlight.translationSettings.enableJapaneseTranslation</code> to <b>true</b>
     </li>
     <li><b>Gemini API翻訳:</b> Google Geminiを翻訳に使用するには、VS Codeの設定で以下を設定してください:<br>
-      <code>owlspotlight.translationSettings.translationProvider</code> を <b>"gemini"</b> に<br>
       <code>owlspotlight.translationSettings.geminiApiKey</code> に <b>Gemini APIキー</b> を<br>
       <code>owlspotlight.translationSettings.enableJapaneseTranslation</code> を <b>true</b> に
     </li>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,15 +5,14 @@ import * as path from 'path';
 import * as os from 'os';
 import * as cp from 'child_process';
 
-// Translate Japanese query to English using Gemini API or LibreTranslate
+// Translate Japanese query to English using Gemini API
 async function translateJapaneseToEnglish(text: string): Promise<string> {
     const config = vscode.workspace.getConfiguration('owlspotlight');
     // フラットな設定取得に対応
     const enabled = config.get<boolean>('enableJapaneseTranslation', false);
     const geminiApiKey = config.get<string>('geminiApiKey', '');
-    // translationProviderや他の設定は従来通り取得
+    // 追加設定を取得 (将来の拡張用)
     const tSettings = config.get<any>('translationSettings', {});
-    const provider = tSettings.translationProvider || 'libretranslate';
     
     if (!enabled) {
         return text;
@@ -24,11 +23,7 @@ async function translateJapaneseToEnglish(text: string): Promise<string> {
         return text;
     }
     
-    if (provider === 'gemini') {
-        return await translateWithGemini(text, { ...tSettings, geminiApiKey });
-    } else {
-        return await translateWithLibreTranslate(text, tSettings);
-    }
+    return await translateWithGemini(text, { ...tSettings, geminiApiKey });
 }
 
 // Gemini APIを使用した翻訳
@@ -64,26 +59,6 @@ ${text}`;
     }
 }
 
-// LibreTranslateを使用した翻訳（既存の機能）
-async function translateWithLibreTranslate(text: string, tSettings: any): Promise<string> {
-    const url = tSettings.translationApiUrl || 'https://libretranslate.de/translate';
-    const apiKey = tSettings.translationApiKey || '';
-    
-    try {
-        const res = await fetch(url, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ q: text, source: 'ja', target: 'en', api_key: apiKey })
-        });
-        const data: any = await res.json();
-        if (data && data.translatedText) {
-            return data.translatedText as string;
-        }
-    } catch (e) {
-        vscode.window.showWarningMessage('LibreTranslate translation failed: ' + e);
-    }
-    return text;
-}
 
 // インデントベースで関数の範囲を検出する関数
 async function getFunctionRangeByIndent(doc: vscode.TextDocument, startPos: vscode.Position): Promise<vscode.Range> {


### PR DESCRIPTION
## Summary
- drop LibreTranslate implementation and default to Gemini translation
- update help docs accordingly

## Testing
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com/api/releases/stable?released=true as JSON)*

------
https://chatgpt.com/codex/tasks/task_e_6842498bff5c832cac4b9bada4f072df