### PR TITLE
Avoid duplicate embedding generation

### DIFF
--- a/model_server/indexer.py
+++ b/model_server/indexer.py
@@ -3,29 +3,46 @@ import numpy as np
 from model import encode_code, get_model_embedding_dim
 
 class CodeIndexer:
-    def __init__(self, dim: int = None):
+    def __init__(self, dim: int | None = None):
+        """Simple wrapper around a FAISS index with optional embedding cache."""
+
         # Dynamically determine embedding dimension from the model if not provided
         if dim is None:
             dim = get_model_embedding_dim()
         self.index = faiss.IndexFlatIP(dim)
-        self.metadata = []
-        self.functions = []  # 関数リスト
-        self.code2emb = {}   # コード文字列→埋め込みベクトル
+        self.metadata: list[dict] = []
+        self.functions: list[dict] = []  # 関数リスト
+        self.code2emb: dict[str, np.ndarray] = {}   # コード文字列→埋め込みベクトル
 
-    def add_functions(self, functions: list[dict]):
+    def add_functions(self, functions: list[dict], embeddings: np.ndarray | None = None):
+        """Add functions to the index.
+
+        If ``embeddings`` is provided, it is used directly. Otherwise the
+        embeddings are generated on demand via :func:`encode_code`.
+        """
+
         # 空のリストが渡された場合は何もしない
         if not functions:
             return
-            
+
         codes = [f["code"] for f in functions]
-        new_codes = [c for c in codes if c not in self.code2emb]
-        if new_codes:
-            print(f"🔄 Encoding {len(new_codes)} new code snippets...")
-            new_embs = encode_code(new_codes, show_progress=True)
-            for c, e in zip(new_codes, new_embs):
+
+        if embeddings is not None:
+            if len(embeddings) != len(functions):
+                raise ValueError("Embeddings length must match number of functions")
+            for c, e in zip(codes, embeddings):
                 self.code2emb[c] = e
-        embeddings = np.stack([self.code2emb[c] for c in codes])
-        self.index.add(embeddings)
+            embeddings_to_add = embeddings
+        else:
+            new_codes = [c for c in codes if c not in self.code2emb]
+            if new_codes:
+                print(f"🔄 Encoding {len(new_codes)} new code snippets...")
+                new_embs = encode_code(new_codes, show_progress=True)
+                for c, e in zip(new_codes, new_embs):
+                    self.code2emb[c] = e
+            embeddings_to_add = np.stack([self.code2emb[c] for c in codes])
+
+        self.index.add(embeddings_to_add)
         self.metadata.extend(functions)
         self.functions.extend(functions)
 


### PR DESCRIPTION
## Summary
- prevent duplicate encoding of code by optionally passing precomputed embeddings to `CodeIndexer`
- reuse loaded embeddings when reading the index from disk
- reuse generated embeddings when constructing the index in `build_index`

## Testing
- `pytest -q`
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com/api/releases/stable?released=true as JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68528db1c1dc832c9106891f3ad803c1